### PR TITLE
Add additional hashes to the mazzaroth libraries

### DIFF
--- a/src/external/crypto.rs
+++ b/src/external/crypto.rs
@@ -1,6 +1,6 @@
-use super::externs::{_sha256, _sha3_256, _keccak256, _shake256};
+use super::externs::{_sha256, _sha3_256, _sha3_512, _keccak256, _shake256};
 
-/// Calls a host function to Sha3_256 data and return the hash
+/// Calls a host function to Sha256 data and return the hash
 pub fn sha256(data: Vec<u8>) -> Vec<u8> {
     // Create Vec to store hash
     let mut hash = Vec::with_capacity(32 as usize); // 32 byte (256) hash
@@ -22,7 +22,18 @@ pub fn sha3_256(data: Vec<u8>) -> Vec<u8> {
     hash
 }
 
-/// Calls a host function to Sha3_256 data and return the hash
+/// Calls a host function to Sha3_512 data and return the hash
+pub fn sha3_512(data: Vec<u8>) -> Vec<u8> {
+    // Create Vec to store hash
+    let mut hash = Vec::with_capacity(64 as usize); // 64 byte (512) hash
+    unsafe { hash.set_len(64 as usize) };
+
+    unsafe { _sha3_512(data.as_ptr(), data.len(), hash.as_mut_ptr()) };
+
+    hash
+}
+
+/// Calls a host function to keccak256 data and return the hash
 pub fn keccak256(data: Vec<u8>) -> Vec<u8> {
     // Create Vec to store hash
     let mut hash = Vec::with_capacity(32 as usize); // 32 byte (256) hash
@@ -33,7 +44,7 @@ pub fn keccak256(data: Vec<u8>) -> Vec<u8> {
     hash
 }
 
-/// Calls a host function to Sha3_256 data and return the hash
+/// Calls a host function to shake256 data and return the hash
 pub fn shake256(data: Vec<u8>) -> Vec<u8> {
     // Create Vec to store hash
     let mut hash = Vec::with_capacity(32 as usize); // 32 byte (256) hash
@@ -43,3 +54,4 @@ pub fn shake256(data: Vec<u8>) -> Vec<u8> {
 
     hash
 }
+

--- a/src/external/externs.rs
+++ b/src/external/externs.rs
@@ -39,6 +39,9 @@ extern "C" {
     /// Host hashing function: sha3_256
     pub(crate) fn _sha3_256(data: *const u8, data_length: usize, hash: *mut u8);
 
+    /// Host hashing function: sha3_512
+    pub(crate) fn _sha3_512(data: *const u8, data_length: usize, hash: *mut u8);
+
     /// Host hashing function: keccak256
     pub(crate) fn _keccak256(data: *const u8, data_length: usize, hash: *mut u8);
 


### PR DESCRIPTION
Adding calls to the additional hashing algorithms available now in our cyrpto library. These will not work until the rothvm host functions are created for these, which are coming soon in a separate pull request. This does not break any of the current functionality.