### PR TITLE
feat(xdr): no longer prepend the byte length to returns

### DIFF
--- a/src/abi/encoder.rs
+++ b/src/abi/encoder.rs
@@ -17,14 +17,6 @@ impl Encoder {
     pub fn push<T: XDROut<Vec<u8>>>(&mut self, val: T) {
         let mut val_bytes: Vec<u8> = Vec::new();
         val.write_xdr(&mut val_bytes).unwrap();
-        // Push a u32 Length for each encoded item
-        // TODO: Check for fixed length items and don't include this (u32, u64, etc.)
-        let len = val_bytes.len() as u32;
-        let mut len_bytes: Vec<u8> = Vec::new();
-        len.write_xdr(&mut len_bytes).unwrap();
-        self.values_mut().extend_from_slice(&len_bytes);
-
-        // Append bytes after the length
         self.values_mut().extend_from_slice(&val_bytes);
     }
 


### PR DESCRIPTION
We are returning xdr encoded types so this is not necessary.

Breaks anything expecting the byte size prepended to returns.