### PR TITLE
reafactor(naming): switch get_exists to key_exists

### DIFF
--- a/src/external/externs.rs
+++ b/src/external/externs.rs
@@ -33,7 +33,7 @@ extern "C" {
     pub(crate) fn _get_length(key: *const u8, key_length: usize) -> u32;
 
     /// Returns if the key exists in the persistent DB.
-    pub(crate) fn _get_exists(key: *const u8, key_length: usize) -> bool;
+    pub(crate) fn _key_exists(key: *const u8, key_length: usize) -> bool;
 
     /// Get an account name from the persistent DB provided by the runtime.
     /// Parameter value should be the mut pointer to a vector with length and capacity allocated.

--- a/src/external/persistence.rs
+++ b/src/external/persistence.rs
@@ -1,9 +1,9 @@
-use super::externs::{_get, _get_exists, _get_length, _store};
+use super::externs::{_get, _get_length, _key_exists, _store};
 use super::ExternalError;
 
 /// Get the value associated with a string key from the persistent storage for this runtime.
 pub fn get(key: Vec<u8>) -> Result<Vec<u8>, ExternalError> {
-    let exists = unsafe { _get_exists(key.as_ptr(), key.len()) };
+    let exists = unsafe { _key_exists(key.as_ptr(), key.len()) };
     if exists {
         let len = unsafe { _get_length(key.as_ptr(), key.len()) };
         let mut val = Vec::with_capacity(len as usize);


### PR DESCRIPTION
get_exists feels like an awkward naming so we're moving to key_exists

Breaks nothing