### PR TITLE
refactor(externs): switched log host params to fix compiler warnings

### DIFF
--- a/src/external/errors.rs
+++ b/src/external/errors.rs
@@ -8,7 +8,8 @@ use std::panic;
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
         fn hook_impl(info: &panic::PanicInfo) {
-            unsafe { _log_error(info.to_string()) };
+            let val = info.to_string().into_bytes();
+            unsafe { _log_error(val.as_ptr(), val.len()) };
         }
     } else {
         use std::io::{self, Write};

--- a/src/external/externs.rs
+++ b/src/external/externs.rs
@@ -1,7 +1,6 @@
 pub const PRIVATE_KEY_LENGTH: usize = 32;
 pub const PUBLIC_KEY_LENGTH: usize = 32;
 
-#[no_mangle]
 extern "C" {
     /// Fetches input from the Runtime.
     /// Parameter input should be the mut pointer to a vector with length and capacity allocated.
@@ -100,7 +99,8 @@ extern "C" {
     ) -> u32;
 
     /// Return error messages to the host runtime
-    pub(crate) fn _log_error(msg: String);
+    pub(crate) fn _log_error(msg: *const u8, msg_length: usize);
 
-    pub(crate) fn _log(msg: String);
+    /// Log message to host runtime
+    pub(crate) fn _log(msg: *const u8, msg_length: usize);
 }

--- a/src/external/log.rs
+++ b/src/external/log.rs
@@ -2,5 +2,6 @@ use super::externs::_log;
 
 // public log function that wraps the host call
 pub fn log(msg: String) {
-    unsafe { _log(msg) }
+    let val = msg.into_bytes();
+    unsafe { _log(val.as_ptr(), val.len()) }
 }


### PR DESCRIPTION
Host log functions are now passed as pointer and length like all other host functions.  No longer receive compiler warning about FFI-safe values.

Dependent on update to RothVM.