### PR TITLE
refactor(json): json file name changed to use Cargo Pkg Name if set

### DIFF
--- a/mazzaroth-wasm-derive/src/json.rs
+++ b/mazzaroth-wasm-derive/src/json.rs
@@ -83,7 +83,7 @@ pub fn write_json_abi(intf: &contract::Contract) -> JsonResult<()> {
         target.push("target");
         target.push("json");
         fs::create_dir_all(&target).map_err(|err| JsonError::failed_to_create_dir(err))?;
-        target.push(&format!("{}.json", intf.name()));
+        target.push(&format!("{}.json", env::var("CARGO_PKG_NAME").unwrap_or(intf.name().to_owned())));
         target
     };
 


### PR DESCRIPTION
Changing the name of the json abi file generated from the Macro to use the Cargo Package Name if it is set instead of the Contract name.  

This makes it match the name of the wasm file that gets generated and the file name can be changed by updating the Cargo.toml:

[package]
name = "hello_world"

One reason to switch to this convention is that it will also allow mazzaroth-studio-runner to use the Cargo toml to control file outputs and allow users to share a target directory for dependencies but with separate file outputs, thus speeding up build time.