### PR TITLE
feat(keyquery): clean up host functions and deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ readme = "README.md"
 sha3 = "0.8.1"
 cfg-if = "0.1.3"
 wasm-bindgen = "0.2.20"
-keyquery-builder = { git = "ssh://git@github.com/kochavalabs/keyquery-builder.git", branch = "develop" }
-keyquery-xdr = { git = "ssh://git@github.com/kochavalabs/keyquery-xdr.git", branch = "develop" }
 mazzaroth-xdr = { git = "ssh://git@github.com/kochavalabs/mazzaroth-xdr.git", branch = "develop" }
 xdr-rs-serialize = { git = "ssh://git@github.com/kochavalabs/xdr-rs-serialize.git", branch = "develop" }
 

--- a/src/external/query.rs
+++ b/src/external/query.rs
@@ -1,29 +1,10 @@
 //! Access to the query host functions
 
 #[cfg(not(feature = "host-mock"))]
-use super::externs::{_kq_insert, _kq_query_fetch, _kq_query_run};
-#[cfg(not(feature = "host-mock"))]
-use xdr_rs_serialize::ser::XDROut;
-
-use keyquery_xdr::{Insert, Query};
+use super::externs::{_kq_query_fetch, _kq_query_run};
 
 #[cfg(feature = "host-mock")]
 pub static mut QUERY_RESULT: Option<Vec<u8>> = None;
-
-/// Insert an object into a table defined by a mazzaroth schema
-///
-/// # Arguments
-///
-/// * `insert` - keyquery.xdr.Insert to be inserted into the blockchain state
-#[cfg(not(feature = "host-mock"))]
-pub fn insert(insert: Insert) {
-    let mut insert_bytes: Vec<u8> = Vec::new();
-    insert.write_xdr(&mut insert_bytes).unwrap();
-    unsafe { _kq_insert(insert_bytes.as_ptr(), insert_bytes.len()) };
-}
-
-#[cfg(feature = "host-mock")]
-pub fn insert(_insert: Insert) {}
 
 /// Execute a Query against an uploaded schema in Mazzaroth
 ///
@@ -37,9 +18,8 @@ pub fn insert(_insert: Insert) {}
 ///  * `Some(Vec<u8>)` - xdr encoded result of the query execution
 ///  * None - the query resulted in no results
 #[cfg(not(feature = "host-mock"))]
-pub fn query(query: Query) -> Option<Vec<u8>> {
-    let mut query_bytes: Vec<u8> = Vec::new();
-    query.write_xdr(&mut query_bytes).unwrap();
+pub fn query(query: String) -> Option<Vec<u8>> {
+    let query_bytes: Vec<u8> = query.as_bytes().to_vec();
     let mut hash = Vec::with_capacity(16 as usize); // 32 byte (256) hash
     unsafe { hash.set_len(16 as usize) };
     let len = unsafe { _kq_query_run(query_bytes.as_ptr(), query_bytes.len(), hash.as_ptr()) };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,6 @@ pub use contract::{ContractErrors, ContractInterface};
 #[macro_use]
 extern crate cfg_if;
 
-extern crate keyquery_builder;
-extern crate keyquery_xdr;
 extern crate mazzaroth_xdr;
 extern crate xdr_rs_serialize;
 


### PR DESCRIPTION
We're no longer using schema and keyquery repos, so I'm cleaning up the
keyquery dependencies and host functions to match rothvm.