### PR TITLE
fix(mazzaroth-rs-derive): macro updated to not parse constructor function differently

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ the external host functions available to use.
 The first step to using this library is to include the necessary dependencies.  
 The following 3 dependencies should be included in your Cargo.toml:
 
-mazzaroth-rs
-mazzaroth-rs-derive
+mazzaroth-rs  
+mazzaroth-rs-derive  
 mazzaroth-xdr
 
 Every contract will have a similar base layout for the main function and the contract trait definition.

--- a/mazzaroth-rs-derive/src/json.rs
+++ b/mazzaroth-rs-derive/src/json.rs
@@ -124,20 +124,12 @@ pub struct ReadonlyEntry {
 }
 
 #[derive(Serialize, Debug)]
-pub struct ConstructorEntry {
-    #[serde(rename = "inputs")]
-    pub arguments: Vec<Argument>,
-}
-
-#[derive(Serialize, Debug)]
 #[serde(tag = "type")]
 pub enum AbiEntry {
     #[serde(rename = "function")]
     Function(FunctionEntry),
     #[serde(rename = "readonly")]
     Readonly(ReadonlyEntry),
-    #[serde(rename = "constructor")]
-    Constructor(ConstructorEntry),
 }
 
 #[derive(Serialize, Debug)]
@@ -157,12 +149,6 @@ impl<'a> From<&'a contract::Contract> for Abi {
                 }
                 _ => {}
             }
-        }
-
-        if let Some(constructor) = intf.constructor() {
-            result.push(AbiEntry::Constructor(
-                FunctionEntry::from(constructor).into(),
-            ));
         }
 
         Abi(result)
@@ -219,14 +205,6 @@ impl<'a> From<&'a contract::Function> for ReadonlyEntry {
                     codec: check_codec(item, ty),
                 })
                 .collect(),
-        }
-    }
-}
-
-impl From<FunctionEntry> for ConstructorEntry {
-    fn from(func: FunctionEntry) -> Self {
-        ConstructorEntry {
-            arguments: func.arguments,
         }
     }
 }

--- a/src/external/externs.rs
+++ b/src/external/externs.rs
@@ -71,23 +71,6 @@ extern "C" {
     /// Host hashing function: shake256
     pub(crate) fn _shake256(data: *const u8, data_length: usize, hash: *mut u8);
 
-    /// Host hashing function for generating a cryptographic key pair.
-    /// Currently returns a X25519 elliptic curve key pair, 32 byte private key
-    /// and 32 byte public key
-    pub(crate) fn _generate_key_pair(priv_key: *mut u8, pub_key: *mut u8);
-
-    /// Signs a message using the provided private key. You typically wouldn't be
-    /// signing something by sending your private key to the network, so this is
-    /// mostly for demonstration purposes.
-    /// It uses a 32 byte X25519 elliptic curve private key and returns a 64 byte
-    /// signature.
-    pub(crate) fn _sign_message(
-        priv_key: *const u8,
-        message: *const u8,
-        message_length: usize,
-        signature: *mut u8,
-    );
-
     /// Validates a signature using the provided public key. A Mazzaroth user's
     /// account address can be used as the public key to verify transactions sent
     /// from that user.


### PR DESCRIPTION
Currently the derive macro looks for a function named "constructor" and puts in the abi JSON as a special type "constructor" with no name.  Then the only way to call this function is by providing the input object with the `CONSTRUCTOR` input type.  This isn't currently being supported by RothVM so using the constructor function name just results in a broken ABI JSON and a function that cannot be called.

This updated removes the constructor parsing for the ABI JSON and the execute function.  Now if a contract defines a function called "constructor" it will be parsed like any other function and be callable.

- Also cleaned up README and removed unusable extern functions.