### PR TITLE
feat(mazzaroth-xdr): updates to use mazzaroth-xdr v0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 sha3 = "0.8.1"
 cfg-if = "0.1.3"
 wasm-bindgen = "0.2.20"
-mazzaroth-xdr = "0.4.0"
+mazzaroth-xdr = "0.4.2"
 xdr-rs-serialize = "0.2.5"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 sha3 = "0.8.1"
 cfg-if = "0.1.3"
 wasm-bindgen = "0.2.20"
-mazzaroth-xdr = { git = "ssh://git@github.com/kochavalabs/mazzaroth-xdr.git", branch = "develop" }
-xdr-rs-serialize = { git = "ssh://git@github.com/kochavalabs/xdr-rs-serialize.git", branch = "develop" }
+mazzaroth-xdr = "0.4.0"
+xdr-rs-serialize = "0.2.5"
 
 [features]
 host-mock = []

--- a/mazzaroth-rs-derive/Cargo.toml
+++ b/mazzaroth-rs-derive/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 syn = { version = "0.15.12" , features = ["full", "extra-traits", "parsing"] }
 quote = "0.6.8"
 proc-macro2 = "0.4"
-mazzaroth-xdr = "0.4.0"
+mazzaroth-xdr = "0.4.2"
 xdr-rs-serialize = "0.2.5"
 
 [lib]

--- a/mazzaroth-rs-derive/Cargo.toml
+++ b/mazzaroth-rs-derive/Cargo.toml
@@ -12,9 +12,8 @@ readme = "README.md"
 syn = { version = "0.15.12" , features = ["full", "extra-traits", "parsing"] }
 quote = "0.6.8"
 proc-macro2 = "0.4"
-serde = "1.0.89"
-serde_derive = "1.0.89"
-serde_json = "1.0.24"
+mazzaroth-xdr = "0.4.0"
+xdr-rs-serialize = "0.2.5"
 
 [lib]
 name = "mazzaroth_rs_derive"

--- a/mazzaroth-rs-derive/src/contract.rs
+++ b/mazzaroth-rs-derive/src/contract.rs
@@ -51,7 +51,11 @@ impl Contract {
         };
 
         // Parse the trait items
-        let items = contract_trait.items.into_iter().map(TraitItem::from_contract_item).collect();
+        let items = contract_trait
+            .items
+            .into_iter()
+            .map(TraitItem::from_contract_item)
+            .collect();
 
         Contract {
             name: contract_trait.ident.to_string(),

--- a/mazzaroth-rs-derive/src/json.rs
+++ b/mazzaroth-rs-derive/src/json.rs
@@ -1,7 +1,7 @@
 //! JSON generation
 
-use xdr_rs_serialize::ser::XDROut;
 use mazzaroth_xdr::{Abi, FunctionSignature, Parameter};
+use xdr_rs_serialize::ser::XDROut;
 
 use contract;
 
@@ -111,10 +111,12 @@ pub fn write_json_abi(intf: &contract::Contract) -> JsonResult<()> {
 
     // Serialize the ABI object to JSON bytes
     let mut val_bytes: Vec<u8> = Vec::new();
-    abi.write_json(&mut val_bytes).map_err(|err| JsonError::failed_to_write_json_bytes(err))?;
+    abi.write_json(&mut val_bytes)
+        .map_err(|err| JsonError::failed_to_write_json_bytes(err))?;
 
     // Write JSON Bytes to the target file
-    f.write_all(&val_bytes).map_err(|err| JsonError::failed_to_write_json_abi_file(err))?;
+    f.write_all(&val_bytes)
+        .map_err(|err| JsonError::failed_to_write_json_abi_file(err))?;
 
     Ok(())
 }
@@ -140,16 +142,14 @@ impl<'a> From<&'a contract::Contract> for Abi {
             }
         }
 
-        Abi{
-            functions: result,
-        }
+        Abi { functions: result }
     }
 }
 
 // Trait implementation to build a Function Signature from a Contract function
 impl<'a> From<&'a contract::Function> for FunctionSignature {
     fn from(item: &contract::Function) -> Self {
-       FunctionSignature {
+        FunctionSignature {
             functionType: "".to_string(), // To be set by caller based on function type
             name: item.name.to_string(),
             inputs: item

--- a/mazzaroth-rs-derive/src/json.rs
+++ b/mazzaroth-rs-derive/src/json.rs
@@ -78,7 +78,7 @@ impl std::error::Error for JsonError {
         }
     }
 
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match self {
             JsonError::FailedToCreateDirectory(err) => Some(err),
             JsonError::FailedToCreateJsonFile(err) => Some(err),

--- a/mazzaroth-rs-derive/src/json.rs
+++ b/mazzaroth-rs-derive/src/json.rs
@@ -1,10 +1,13 @@
 //! JSON generation
 
+use xdr_rs_serialize::ser::XDROut;
+use mazzaroth_xdr::{Abi, FunctionSignature, Parameter};
+
 use contract;
-use serde_json;
 
 use std;
 use std::io;
+use std::io::Write;
 
 /// The result type for JSON errors.
 pub type JsonResult<T> = std::result::Result<T, JsonError>;
@@ -14,7 +17,8 @@ pub type JsonResult<T> = std::result::Result<T, JsonError>;
 pub enum JsonError {
     FailedToCreateDirectory(io::Error),
     FailedToCreateJsonFile(io::Error),
-    FailedToWriteJsonAbiFile(serde_json::Error),
+    FailedToWriteJsonAbiFile(io::Error),
+    FailedToWriteJsonBytes(xdr_rs_serialize::error::Error),
 }
 
 impl JsonError {
@@ -31,8 +35,14 @@ impl JsonError {
     }
 
     /// Returns a JSON error indicating that the writing of the JSON
+    /// to bytes failed.
+    pub fn failed_to_write_json_bytes(err: xdr_rs_serialize::error::Error) -> Self {
+        JsonError::FailedToWriteJsonBytes(err)
+    }
+
+    /// Returns a JSON error indicating that the writing of the JSON
     /// abi file failed.
-    pub fn failed_to_write_json_abi_file(err: serde_json::Error) -> Self {
+    pub fn failed_to_write_json_abi_file(err: io::Error) -> Self {
         JsonError::FailedToWriteJsonAbiFile(err)
     }
 }
@@ -45,6 +55,9 @@ impl std::fmt::Display for JsonError {
             }
             JsonError::FailedToCreateJsonFile(err) => {
                 write!(f, "failed to create JSON abi file: {:?}", err)
+            }
+            JsonError::FailedToWriteJsonBytes(err) => {
+                write!(f, "failed to write JSON bytes: {:?}", err)
             }
             JsonError::FailedToWriteJsonAbiFile(err) => {
                 write!(f, "failed to write JSON abi file: {:?}", err)
@@ -60,6 +73,7 @@ impl std::error::Error for JsonError {
                 "failed to create directory for the JSON abi file"
             }
             JsonError::FailedToCreateJsonFile(_) => "failed to create JSON abi file",
+            JsonError::FailedToWriteJsonBytes(_) => "failed to write JSON bytes",
             JsonError::FailedToWriteJsonAbiFile(_) => "failed to write JSON abi file",
         }
     }
@@ -68,6 +82,7 @@ impl std::error::Error for JsonError {
         match self {
             JsonError::FailedToCreateDirectory(err) => Some(err),
             JsonError::FailedToCreateJsonFile(err) => Some(err),
+            JsonError::FailedToWriteJsonBytes(err) => Some(err),
             JsonError::FailedToWriteJsonAbiFile(err) => Some(err),
         }
     }
@@ -87,54 +102,24 @@ pub fn write_json_abi(intf: &contract::Contract) -> JsonResult<()> {
         target
     };
 
+    // Create the target/*.json file
     let mut f =
         fs::File::create(target).map_err(|err| JsonError::failed_to_create_json_file(err))?;
 
+    // Convert the Contract into the Mazzaroth_xdr ABI object
     let abi: Abi = intf.into();
 
-    serde_json::to_writer_pretty(&mut f, &abi)
-        .map_err(|err| JsonError::failed_to_write_json_abi_file(err))?;
+    // Serialize the ABI object to JSON bytes
+    let mut val_bytes: Vec<u8> = Vec::new();
+    abi.write_json(&mut val_bytes).map_err(|err| JsonError::failed_to_write_json_bytes(err))?;
+
+    // Write JSON Bytes to the target file
+    f.write_all(&val_bytes).map_err(|err| JsonError::failed_to_write_json_abi_file(err))?;
 
     Ok(())
 }
 
-#[derive(Serialize, Debug)]
-pub struct FunctionEntry {
-    pub name: String,
-    #[serde(rename = "inputs")]
-    pub arguments: Vec<Argument>,
-    pub outputs: Vec<Argument>,
-    // pub constant: bool, // TODO?
-}
-
-#[derive(Serialize, Debug)]
-pub struct Argument {
-    pub name: String,
-    #[serde(rename = "type")]
-    pub type_: String,
-    pub codec: String,
-}
-
-#[derive(Serialize, Debug)]
-pub struct ReadonlyEntry {
-    pub name: String,
-    #[serde(rename = "inputs")]
-    pub arguments: Vec<Argument>,
-    pub outputs: Vec<Argument>,
-}
-
-#[derive(Serialize, Debug)]
-#[serde(tag = "type")]
-pub enum AbiEntry {
-    #[serde(rename = "function")]
-    Function(FunctionEntry),
-    #[serde(rename = "readonly")]
-    Readonly(ReadonlyEntry),
-}
-
-#[derive(Serialize, Debug)]
-pub struct Abi(pub Vec<AbiEntry>);
-
+// Trait implementation to build an ABI object from the Contract
 impl<'a> From<&'a contract::Contract> for Abi {
     fn from(intf: &contract::Contract) -> Self {
         let mut result = Vec::new();
@@ -142,56 +127,37 @@ impl<'a> From<&'a contract::Contract> for Abi {
             match *item {
                 // contract::Item::Event(ref event) => result.push(AbiEntry::Event(event.into())),
                 contract::TraitItem::Function(ref signature) => {
-                    result.push(AbiEntry::Function(signature.into()))
+                    let mut function: FunctionSignature = signature.into();
+                    function.functionType = "function".to_string();
+                    result.push(function)
                 }
                 contract::TraitItem::Readonly(ref signature) => {
-                    result.push(AbiEntry::Readonly(signature.into()))
+                    let mut function: FunctionSignature = signature.into();
+                    function.functionType = "readonly".to_string();
+                    result.push(function)
                 }
                 _ => {}
             }
         }
 
-        Abi(result)
-    }
-}
-
-impl<'a> From<&'a contract::Function> for FunctionEntry {
-    fn from(item: &contract::Function) -> Self {
-        FunctionEntry {
-            name: item.name.to_string(),
-            arguments: item
-                .arguments
-                .iter()
-                .map(|&(ref pat, ref ty)| Argument {
-                    name: quote! { #pat }.to_string(),
-                    type_: canonicalize_type(ty),
-                    codec: check_codec(item, ty),
-                })
-                .collect(),
-            outputs: item
-                .ret_types
-                .iter()
-                .enumerate()
-                .map(|(idx, ty)| Argument {
-                    name: format!("returnValue{}", idx),
-                    type_: canonicalize_type(ty),
-                    codec: check_codec(item, ty),
-                })
-                .collect(),
+        Abi{
+            functions: result,
         }
     }
 }
 
-impl<'a> From<&'a contract::Function> for ReadonlyEntry {
+// Trait implementation to build a Function Signature from a Contract function
+impl<'a> From<&'a contract::Function> for FunctionSignature {
     fn from(item: &contract::Function) -> Self {
-        ReadonlyEntry {
+       FunctionSignature {
+            functionType: "".to_string(), // To be set by caller based on function type
             name: item.name.to_string(),
-            arguments: item
+            inputs: item
                 .arguments
                 .iter()
-                .map(|&(ref pat, ref ty)| Argument {
+                .map(|&(ref pat, ref ty)| Parameter {
                     name: quote! { #pat }.to_string(),
-                    type_: canonicalize_type(ty),
+                    parameterType: canonicalize_type(ty),
                     codec: check_codec(item, ty),
                 })
                 .collect(),
@@ -199,9 +165,9 @@ impl<'a> From<&'a contract::Function> for ReadonlyEntry {
                 .ret_types
                 .iter()
                 .enumerate()
-                .map(|(idx, ty)| Argument {
+                .map(|(idx, ty)| Parameter {
                     name: format!("returnValue{}", idx),
-                    type_: canonicalize_type(ty),
+                    parameterType: canonicalize_type(ty),
                     codec: check_codec(item, ty),
                 })
                 .collect(),

--- a/mazzaroth-rs-derive/src/lib.rs
+++ b/mazzaroth-rs-derive/src/lib.rs
@@ -73,9 +73,9 @@ extern crate proc_macro2;
 extern crate syn;
 #[macro_use]
 extern crate quote;
-extern crate serde_json;
-#[macro_use]
-extern crate serde_derive;
+
+extern crate mazzaroth_xdr;
+extern crate xdr_rs_serialize;
 
 use proc_macro::TokenStream;
 use proc_macro2::Span;

--- a/mazzaroth-rs-derive/src/lib.rs
+++ b/mazzaroth-rs-derive/src/lib.rs
@@ -17,7 +17,7 @@
 //! call a host function to retrieve function input, execute the function, and return a response.
 //!
 //! Here is a basic Hello World contract example:
-//! ```
+//! ```ignore
 //! // must include the ContractInterface and mazzaroth_abi for compiling the macro
 //! extern crate mazzaroth_rs;
 //! extern crate mazzaroth_rs_derive;
@@ -94,7 +94,7 @@ use json::write_json_abi;
 /// The argument becomes the module name used to construct the contract in main.
 ///
 /// Example:
-/// ```
+/// ```ignore
 /// #[mazzaroth_abi(HelloWorld)]
 /// pub trait HelloWorldContract {
 ///     

--- a/src/abi/decoder.rs
+++ b/src/abi/decoder.rs
@@ -1,5 +1,5 @@
 //! Decodes encoded bytes into an XDR object.
-use mazzaroth_xdr::Parameter;
+use mazzaroth_xdr::Argument;
 use xdr_rs_serialize::de::{read_json_string, XDRIn};
 use xdr_rs_serialize::error::Error;
 
@@ -22,16 +22,16 @@ impl<'a> Decoder<'a> {
     }
 }
 
-/// Decode a vector of Parameters into separate XDR object.
+/// Decode a vector of Arguments into separate XDR object.
 /// Values must implement XDRIn.
 pub struct InputDecoder<'a> {
-    payload: &'a [Parameter],
+    payload: &'a [Argument],
     position: usize,
 }
 
 impl<'a> InputDecoder<'a> {
     /// New decoder for known payload
-    pub fn new(raw: &'a [Parameter]) -> Self {
+    pub fn new(raw: &'a [Argument]) -> Self {
         InputDecoder {
             payload: raw,
             position: 0,
@@ -40,7 +40,7 @@ impl<'a> InputDecoder<'a> {
 
     /// Pop next argument of known type
     pub fn pop<T: XDRIn>(&mut self, typ: &'static str) -> Result<T, Error> {
-        // grab bytes from parameter and advance 1
+        // grab bytes from argument and advance 1
         let bytes = &self.payload[self.position].t[..];
         self.position += 1;
         match typ {
@@ -55,7 +55,7 @@ impl<'a> InputDecoder<'a> {
     }
 
     /// Decoder payload
-    pub fn payload(&self) -> &'a [Parameter] {
+    pub fn payload(&self) -> &'a [Argument] {
         self.payload
     }
 }

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -8,6 +8,5 @@ pub trait ContractInterface {
 #[derive(Debug)]
 pub enum ContractErrors {
     InvalidInputType,
-    InvalidWriteMethodName,
-    InvalidReadMethodName,
+    InvalidFunctionName,
 }

--- a/src/external/account.rs
+++ b/src/external/account.rs
@@ -1,82 +1,10 @@
 //! Provides access to contract account objects stored in state.
 
 #[cfg(not(feature = "host-mock"))]
-use super::externs::{_get_account_name, _get_account_name_length, _is_owner, _set_account_name};
-
-#[cfg(not(feature = "host-mock"))]
-use std::str;
-
-#[cfg(feature = "host-mock")]
-pub static mut NAME: Option<String> = None;
+use super::externs::_is_owner;
 
 #[cfg(feature = "host-mock")]
 pub static mut OWNER: bool = false;
-
-/// Get the value associated with a string key from the persistent storage for this runtime.
-///
-/// # Arguments
-///
-/// * `key` - The public key of the account to access
-///
-/// # Returns
-///
-/// * `String` - The name stored in the account object
-///
-/// # Example
-///
-/// ```ignore
-/// use mazzaroth_rs::account;
-/// let name = account::get_name(vec![0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-/// ```
-#[cfg(not(feature = "host-mock"))]
-pub fn get_name(key: Vec<u8>) -> String {
-    let len = unsafe { _get_account_name_length(key.as_ptr(), key.len()) };
-    let mut val = Vec::with_capacity(len as usize);
-    unsafe { val.set_len(len as usize) };
-    unsafe { _get_account_name(key.as_ptr(), key.len(), val.as_mut_ptr()) };
-    // Convert name to String
-    str::from_utf8(&val).unwrap().to_owned()
-}
-
-#[cfg(feature = "host-mock")]
-pub fn get_name(_key: Vec<u8>) -> String {
-    unsafe {
-        match NAME.clone() {
-            Some(name) => name,
-            None => "".to_string(),
-        }
-    }
-}
-
-/// Store an account name in the persistent storage for this runtime.
-///
-/// # Arguments
-///
-/// * `key` - The public key of the account to access
-/// * `name` - The String name to store in the account
-///
-/// # Returns
-///
-/// * `None`
-///
-/// # Example
-///
-/// ```ignore
-/// use mazzaroth_rs::account;
-/// account::set_name(vec![0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "name");
-/// ```
-#[cfg(not(feature = "host-mock"))]
-pub fn set_name(key: Vec<u8>, name: String) {
-    let val = name.into_bytes();
-    unsafe { _set_account_name(key.as_ptr(), key.len(), val.as_ptr(), val.len()) };
-}
-
-#[cfg(feature = "host-mock")]
-pub fn set_name(_key: Vec<u8>, name: String) {
-    unsafe {
-        NAME = Some(name.clone());
-    }
-}
 
 /// Check if an account is the owner of the channel.
 ///

--- a/src/external/externs.rs
+++ b/src/external/externs.rs
@@ -36,19 +36,6 @@ extern "C" {
     /// Returns if the key exists in the persistent DB.
     pub(crate) fn _key_exists(key: *const u8, key_length: usize) -> bool;
 
-    /// Get an account name from the persistent DB provided by the runtime.
-    /// Parameter value should be the mut pointer to a vector with length and capacity allocated.
-    /// Call _get_account_name_length first to get a length to allocate the value vector.
-    pub(crate) fn _get_account_name(key: *const u8, key_length: usize, value: *mut u8);
-
-    /// Set an account name in the persistent DB provided by the runtime.
-    pub(crate) fn _set_account_name(
-        key: *const u8,
-        key_length: usize,
-        value: *const u8,
-        value_length: usize,
-    );
-
     /// Returns the length of the name associated with the account key from the persistent DB.
     /// Use the return to set the capacity and length of a vector to call _get_account_name.
     pub(crate) fn _get_account_name_length(key: *const u8, key_length: usize) -> u32;


### PR DESCRIPTION
# Description

- Update to use JSON object generated in mazzaroth-xdr and remove serde dependency.
- Removed `Input` object as payload to execute function, replaced with `Call` object.
- Removed execution split of readonly and write functions.  Now Readonly tag is only used to set the function type in the JSON abi.

There are several differences in the layout of the JSON ABI file after these changes:
- The output file now no longer includes spacing or newlines.
- The "type" field of functions has been renamed to "functionType".
- The file now includes the full ABI object instead of just the array of functions.  So it will start with {"functions":[]}, which matches the full ABI mazzaroth-xdr object.
 
 ## Testing
 
 Generated JSON Abi for the [Full Contract Example](https://github.com/kochavalabs/full-contract-example):
 
 Previously:
 ```JSON
 [
  {
    "type": "function",
    "name": "setup",
    "inputs": [],
    "outputs": [
      {
        "name": "returnValue0",
        "type": "bool",
        "codec": "bytes"
      }
    ]
  },
  {
    "type": "readonly",
    "name": "simple",
    "inputs": [],
    "outputs": [
      {
        "name": "returnValue0",
        "type": "string",
        "codec": "bytes"
      }
    ]
  },
  {
    "type": "function",
    "name": "args",
    "inputs": [
      {
        "name": "one",
        "type": "string",
        "codec": "bytes"
      },
      {
        "name": "two",
        "type": "string",
        "codec": "bytes"
      },
      {
        "name": "three",
        "type": "string",
        "codec": "bytes"
      }
    ],
    "outputs": [
      {
        "name": "returnValue0",
        "type": "uint32",
        "codec": "bytes"
      }
    ]
  },
  {
    "type": "function",
    "name": "complex",
    "inputs": [
      {
        "name": "foo_arg",
        "type": "Foo",
        "codec": "bytes"
      },
      {
        "name": "bar_arg",
        "type": "Bar",
        "codec": "bytes"
      }
    ],
    "outputs": [
      {
        "name": "returnValue0",
        "type": "string",
        "codec": "bytes"
      }
    ]
  },
  {
    "type": "function",
    "name": "insert_foo",
    "inputs": [
      {
        "name": "foo",
        "type": "Foo",
        "codec": "bytes"
      }
    ],
    "outputs": [
      {
        "name": "returnValue0",
        "type": "int32[]",
        "codec": "bytes"
      }
    ]
  },
  {
    "type": "function",
    "name": "query_foo",
    "inputs": [
      {
        "name": "where_clause",
        "type": "string",
        "codec": "bytes"
      }
    ],
    "outputs": [
      {
        "name": "returnValue0",
        "type": "Foo[]",
        "codec": "bytes"
      }
    ]
  }
]
 ```
 
 After changes:
 
 ```JSON
 {"functions":[{"functionType":"function","name":"setup","inputs":[],"outputs":[{"name":"returnValue0","parameterType":"bool","codec":"bytes"}]},{"functionType":"readonly","name":"simple","inputs":[],"outputs":[{"name":"returnValue0","parameterType":"string","codec":"bytes"}]},{"functionType":"function","name":"args","inputs":[{"name":"one","parameterType":"string","codec":"bytes"},{"name":"two","parameterType":"string","codec":"bytes"},{"name":"three","parameterType":"string","codec":"bytes"}],"outputs":[{"name":"returnValue0","parameterType":"uint32","codec":"bytes"}]},{"functionType":"function","name":"complex","inputs":[{"name":"foo_arg","parameterType":"Foo","codec":"bytes"},{"name":"bar_arg","parameterType":"Bar","codec":"bytes"}],"outputs":[{"name":"returnValue0","parameterType":"string","codec":"bytes"}]},{"functionType":"function","name":"insert_foo","inputs":[{"name":"foo","parameterType":"Foo","codec":"bytes"}],"outputs":[{"name":"returnValue0","parameterType":"int32[]","codec":"bytes"}]},{"functionType":"function","name":"query_foo","inputs":[{"name":"where_clause","parameterType":"string","codec":"bytes"}],"outputs":[{"name":"returnValue0","parameterType":"Foo[]","codec":"bytes"}]}]}
 ```
 
 Pretty Printed with jq:
 
 ```JSON
 {
  "functions": [
    {
      "functionType": "function",
      "name": "setup",
      "inputs": [],
      "outputs": [
        {
          "name": "returnValue0",
          "parameterType": "bool",
          "codec": "bytes"
        }
      ]
    },
    {
      "functionType": "readonly",
      "name": "simple",
      "inputs": [],
      "outputs": [
        {
          "name": "returnValue0",
          "parameterType": "string",
          "codec": "bytes"
        }
      ]
    },
    {
      "functionType": "function",
      "name": "args",
      "inputs": [
        {
          "name": "one",
          "parameterType": "string",
          "codec": "bytes"
        },
        {
          "name": "two",
          "parameterType": "string",
          "codec": "bytes"
        },
        {
          "name": "three",
          "parameterType": "string",
          "codec": "bytes"
        }
      ],
      "outputs": [
        {
          "name": "returnValue0",
          "parameterType": "uint32",
          "codec": "bytes"
        }
      ]
    },
    {
      "functionType": "function",
      "name": "complex",
      "inputs": [
        {
          "name": "foo_arg",
          "parameterType": "Foo",
          "codec": "bytes"
        },
        {
          "name": "bar_arg",
          "parameterType": "Bar",
          "codec": "bytes"
        }
      ],
      "outputs": [
        {
          "name": "returnValue0",
          "parameterType": "string",
          "codec": "bytes"
        }
      ]
    },
    {
      "functionType": "function",
      "name": "insert_foo",
      "inputs": [
        {
          "name": "foo",
          "parameterType": "Foo",
          "codec": "bytes"
        }
      ],
      "outputs": [
        {
          "name": "returnValue0",
          "parameterType": "int32[]",
          "codec": "bytes"
        }
      ]
    },
    {
      "functionType": "function",
      "name": "query_foo",
      "inputs": [
        {
          "name": "where_clause",
          "parameterType": "string",
          "codec": "bytes"
        }
      ],
      "outputs": [
        {
          "name": "returnValue0",
          "parameterType": "Foo[]",
          "codec": "bytes"
        }
      ]
    }
  ]
}
```