### PR TITLE
feat(xdr): update to use mazzaroth-xdr v0.5.0 and xdr-rs-serialize v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mazzaroth-rs"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Kochavalabs <dev@mazzaroth.io>"]
 description = "Mazzaroth Rust library"
 license = "MIT"
@@ -12,8 +12,8 @@ readme = "README.md"
 sha3 = "0.8.1"
 cfg-if = "0.1.3"
 wasm-bindgen = "0.2.20"
-mazzaroth-xdr = "0.4.2"
-xdr-rs-serialize = "0.2.5"
+mazzaroth-xdr = "0.5.0"
+xdr-rs-serialize = "0.3.0"
 
 [features]
 host-mock = []

--- a/mazzaroth-rs-derive/Cargo.toml
+++ b/mazzaroth-rs-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mazzaroth-rs-derive"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Kochavalabs <dev@mazzaroth.io>"]
 description = "Mazzaroth Rust library derivation macros"
 license = "MIT"
@@ -12,8 +12,8 @@ readme = "README.md"
 syn = { version = "0.15.12" , features = ["full", "extra-traits", "parsing"] }
 quote = "0.6.8"
 proc-macro2 = "0.4"
-mazzaroth-xdr = "0.4.2"
-xdr-rs-serialize = "0.2.5"
+mazzaroth-xdr = "0.5.0"
+xdr-rs-serialize = "0.3.0"
 
 [lib]
 name = "mazzaroth_rs_derive"


### PR DESCRIPTION
# Description

- Updated dependencies so contracts compiled with mazzaroth-rs will use xdr-rs-serialize v0.3.0 along with the associated mazzaroth-xdr v0.5.0
- Bumped version to v0.5.0 for release.