### PR TITLE
feat(derive): updated abi json to generate with updated fields for mazzaroth-xdr v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 sha3 = "0.8.1"
 cfg-if = "0.1.3"
 wasm-bindgen = "0.2.20"
-mazzaroth-xdr = "0.5.0"
+mazzaroth-xdr = "0.6.0"
 xdr-rs-serialize = "0.3.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mazzaroth-rs"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kochavalabs <dev@mazzaroth.io>"]
 description = "Mazzaroth Rust library"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 sha3 = "0.8.1"
 cfg-if = "0.1.3"
 wasm-bindgen = "0.2.20"
-mazzaroth-xdr = "0.6.0"
+mazzaroth-xdr = "0.6.1"
 xdr-rs-serialize = "0.3.0"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ impl HelloWorldContract for Hello {
 }
 ```
 
+## Running Tests
+
+```console
+cargo test --features host-mock
+```
+
 ## Generating Documentation
 
 From the root directory run the command:

--- a/mazzaroth-rs-derive/Cargo.toml
+++ b/mazzaroth-rs-derive/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 syn = { version = "0.15.12" , features = ["full", "extra-traits", "parsing"] }
 quote = "0.6.8"
 proc-macro2 = "0.4"
-mazzaroth-xdr = "0.5.0"
+mazzaroth-xdr = "0.6.0"
 xdr-rs-serialize = "0.3.0"
 
 [lib]

--- a/mazzaroth-rs-derive/Cargo.toml
+++ b/mazzaroth-rs-derive/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 syn = { version = "0.15.12" , features = ["full", "extra-traits", "parsing"] }
 quote = "0.6.8"
 proc-macro2 = "0.4"
-mazzaroth-xdr = "0.6.0"
+mazzaroth-xdr = "0.6.1"
 xdr-rs-serialize = "0.3.0"
 
 [lib]

--- a/mazzaroth-rs-derive/Cargo.toml
+++ b/mazzaroth-rs-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mazzaroth-rs-derive"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kochavalabs <dev@mazzaroth.io>"]
 description = "Mazzaroth Rust library derivation macros"
 license = "MIT"

--- a/src/abi/decoder.rs
+++ b/src/abi/decoder.rs
@@ -17,7 +17,7 @@ impl<'a> Decoder<'a> {
 
     /// Pop next argument of known type
     pub fn pop<T: XDRIn>(&mut self) -> Result<T, Error> {
-        let bytes = &self.payload[..];
+        let bytes = &self.payload;
         Ok(T::read_xdr(bytes)?.0)
     }
 }

--- a/src/external/account.rs
+++ b/src/external/account.rs
@@ -44,10 +44,4 @@ mod tests {
         }
         assert_eq!(is_owner(vec![]), true);
     }
-
-    #[test]
-    fn test_get_name_set() {
-        set_name(vec![], "asdf".to_string());
-        assert_eq!(get_name(vec![]), "asdf".to_string());
-    }
 }

--- a/src/external/sql.rs
+++ b/src/external/sql.rs
@@ -23,8 +23,8 @@ pub static mut INSERT_RESULT: Result<u32, u32> = Ok(0);
 #[cfg(not(feature = "host-mock"))]
 pub fn exec(query: String) -> Option<Vec<u8>> {
     let query_bytes: Vec<u8> = query.as_bytes().to_vec();
-    let mut hash = Vec::with_capacity(16 as usize); // 32 byte (256) hash
-    unsafe { hash.set_len(16 as usize) };
+    let mut hash = Vec::with_capacity(16); // 32 byte (256) hash
+    unsafe { hash.set_len(16) };
     let len = unsafe { _kq_query_run(query_bytes.as_ptr(), query_bytes.len(), hash.as_ptr()) };
     if len == 0 {
         return None;


### PR DESCRIPTION
# Description

Made updates to the ABI JSON format based on the mazzaroth-xdr v0.6.0 redesign.

Updates include:

- Add "version" field to top level ABI object.  Pulling the metadata for the Cargo toml to match the version of this library.
- Update FunctionSignature to use an enum for "functionType" which can be either READ or WRITE
- Renamed FunctionSignature "name" to "functionName", "input" to "parameters", and "outputs" to "returns"
- Renamed Parameter "name" field to "parameterName"
- Removed the "codec" field
- Updated parameterType field to use "json" for custom objects instead of the given object name

Fixed a few Rust compile warnings in mazzaroth-rs as well as removed broken tests.

Updated README with instructions for running tests with host-mock feature.