### PR TITLE
deps(mazzaroth-xdr): bump to version v0.8.1 of mazzaroth-xdr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mazzaroth-rs"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Kochavalabs <dev@mazzaroth.io>"]
 description = "Mazzaroth Rust library"
 license = "MIT"
@@ -12,7 +12,7 @@ readme = "README.md"
 sha3 = "0.8.1"
 cfg-if = "0.1.3"
 wasm-bindgen = "0.2.20"
-mazzaroth-xdr = "0.7.1"
+mazzaroth-xdr = "0.8.1"
 xdr-rs-serialize = "0.3.0"
 
 [features]

--- a/mazzaroth-rs-derive/Cargo.toml
+++ b/mazzaroth-rs-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mazzaroth-rs-derive"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Kochavalabs <dev@mazzaroth.io>"]
 description = "Mazzaroth Rust library derivation macros"
 license = "MIT"
@@ -12,7 +12,7 @@ readme = "README.md"
 syn = { version = "0.15.12" , features = ["full", "extra-traits", "parsing"] }
 quote = "0.6.8"
 proc-macro2 = "0.4"
-mazzaroth-xdr = "0.7.1"
+mazzaroth-xdr = "0.8.1"
 xdr-rs-serialize = "0.3.0"
 
 [lib]


### PR DESCRIPTION
# Description

Update to use mazzaroth-xdr v0.8.1